### PR TITLE
Pentaho Removal of conn strings

### DIFF
--- a/.github/workflows/build_pentaho_remove_image.yml
+++ b/.github/workflows/build_pentaho_remove_image.yml
@@ -42,18 +42,18 @@ jobs:
       id: meta
       uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
       with:
-        images: auscat/pentaho-remove-conns
+        images: auscat/pentaho-remove-conn
 
     - name: Build and push Docker Image to Dockerhub 
       uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
       with:
         context: ./
         push: true
-        tags: auscat/pentaho-remove-conns
+        tags: auscat/pentaho-remove-conn:latest
 
     - name: Build and Push Docker Image to GHCR
       uses: docker/build-push-action@v3
       with:
         context: ./
         push: true
-        tags: ghcr.io/australiancancerdatanetwork/auscat/pentaho-remove-conns
+        tags: ghcr.io/australiancancerdatanetwork/auscat/pentaho-remove-conn

--- a/.github/workflows/build_pentaho_remove_image.yml
+++ b/.github/workflows/build_pentaho_remove_image.yml
@@ -1,0 +1,59 @@
+# Pipeline to build and push the AusCAT Remove Pentaho sensitive connection strings
+# Docker Image to the `auscat` DockerHub and to the australiancancerdatanetwork/auscat_util
+# GitHub Container Registry (GHCR)
+name: Pentaho remove conn strings Docker Image Build/Push
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  push:
+    branches: 
+      - 'main'
+
+jobs:
+  build-push:
+    name: Build/Push remove conn strings Docker Image to GHCR and DockerHub
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+    - name: Checkout `auscat_util` repository
+      uses: actions/checkout@v3
+
+    - name: Login to GHCR
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Login to DockerHub
+      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Extract metadata for Docker
+      id: meta
+      uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+      with:
+        images: auscat/pentaho-remove-conns
+
+    - name: Build and push Docker Image to Dockerhub 
+      uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      with:
+        context: ./
+        push: true
+        tags: auscat/pentaho-remove-conns
+
+    - name: Build and Push Docker Image to GHCR
+      uses: docker/build-push-action@v3
+      with:
+        context: ./
+        push: true
+        tags: ghcr.io/australiancancerdatanetwork/auscat/pentaho-remove-conns

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-# Build command:    docker build -t auscat/pentaho-remove-conns:latest .
-# Run command:      docker run --volume ./local/pentaho/directory/:/path/to/mount/to --env PATH_TO_PENTAHO_FILES=/path/to/your/mounted/folder auscat/pentaho-remove-conns:latest
-# Example:          docker run --volume ./data:/projects/data --env PATH_TO_PENTAHO_FILES=/projects auscat/pentaho-remove-conns:latest
+# Build command:    docker build -t auscat/pentaho-remove-conn:latest .
+# Run command:      docker run --volume ./local/pentaho/directory/:/path/to/mount/to --env PATH_TO_PENTAHO_FILES=/path/to/your/mounted/folder auscat/pentaho-remove-conn:latest
+# Example:          docker run --volume ./data:/projects/data --env PATH_TO_PENTAHO_FILES=/projects/data auscat/pentaho-remove-conn:latest
 FROM python:3.7.16-slim-buster
 
 ENV PATH_TO_PENTAHO_FILES placeholder
 
 WORKDIR /projects
-
 ADD ./reqs.txt .
 RUN pip install -r reqs.txt
 RUN pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Build command:    docker build -t auscat/pentaho-remove-conns:latest .
+# Run command:      docker run --volume ./local/pentaho/directory/:/path/to/mount/to --env PATH_TO_PENTAHO_FILES=/path/to/your/mounted/folder auscat/pentaho-remove-conns:latest
+# Example:          docker run --volume ./data:/projects/data --env PATH_TO_PENTAHO_FILES=/projects auscat/pentaho-remove-conns:latest
+FROM python:3.7.16-slim-buster
+
+ENV PATH_TO_PENTAHO_FILES placeholder
+
+WORKDIR /projects
+
+ADD ./reqs.txt .
+RUN pip install -r reqs.txt
+RUN pip install --upgrade pip
+
+ADD ./auscatutil ./auscatutil
+ADD ./remove_conn_strs_pentaho.py .
+
+ENTRYPOINT python remove_conn_strs_pentaho.py ${PATH_TO_PENTAHO_FILES}

--- a/auscatutil/queryfunctions.py
+++ b/auscatutil/queryfunctions.py
@@ -494,9 +494,10 @@ class PentahoConnection:
         and the contents that are within then resave the file in the same location.
         """
         for path in self.pathlist:
-            for filename in os.listdir(path):
-                if filename.endswith(".ktr") or filename.endswith(".kjb"):
-                    tree = etree.parse(os.path.join(path, filename))
-                    etree.strip_elements(tree, "{*}connection", with_tail=True)
-                    save = os.path.join(path, filename)
-                    tree.write(save)
+            for root, dirs, files in os.walk(path):
+                for filename in files:
+                    if filename.endswith(".ktr") or filename.endswith(".kjb"):
+                        tree = etree.parse(os.path.join(root, filename))
+                        etree.strip_elements(tree, "{*}connection", with_tail=True)
+                        save = os.path.join(root, filename)
+                        tree.write(save)

--- a/remove_conn_strs_pentaho.py
+++ b/remove_conn_strs_pentaho.py
@@ -1,0 +1,41 @@
+"""
+Script to remove database connection strings from Pentaho KTR and KJB files, before they can
+pushed back to github
+
+Example usage:
+    python remove_conn_strs_pentaho.py PATH_TO_PENTAHO_FILES
+
+    where:
+        PATH_TO_PENTAHO_FILES: relative or absolute path to the directory that holds the pentaho files
+"""
+
+import logging
+import os
+import sys
+
+from auscatutil.queryfunctions import PentahoConnection
+
+logging.getLogger().setLevel(logging.INFO)
+
+def main():
+    if len(sys.argv) != 2:
+        logging.error(f" Example usage: `python remove_conn_strs_pentaho.py PATH_TO_PENTAHO_FILES`")
+        exit(1)
+    elif not os.path.isdir(sys.argv[1]):
+        logging.error(" Please provide a valid path to the Pentaho files!")
+        exit(1)
+
+    path_to_files_to_strip = sys.argv[1]
+    abs_path_to_files_to_strip = os.path.abspath(path_to_files_to_strip)
+
+    try:
+        logging.info(f" Attempting to remove sensitive info from {abs_path_to_files_to_strip} files...")
+        pentaho_conn = PentahoConnection([path_to_files_to_strip])
+        pentaho_conn.remove_connections()
+        logging.info(" Done!")
+    except Exception as e:
+        logging.error(f" Could not remove sensitive info from files in {path_to_files_to_strip}, {e}")
+        exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/reqs.txt
+++ b/reqs.txt
@@ -1,0 +1,7 @@
+lxml
+numpy
+pandas
+psycopg2-binary
+pyyaml
+SPARQLWrapper
+sqlalchemy


### PR DESCRIPTION
Hi @pchlap,

Built a dockerfile to run the script to remove sensitive conn strings from pentaho files. I've included some example instructions on building and running it. I'll also write up some documentation on how this needs to be run in the pentaho workflow, which I'll do in the auscatverse docs for pentaho. Also got a github action to build and push this image on `main` merges. 

I've tested this out locally on my machine and it works. Will also give this a go at Liverpool before trying at other centres. Let me know what you think, thanks!